### PR TITLE
Pass config to `rlr_audio_propagation`

### DIFF
--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -723,3 +723,21 @@ def test_simulated_sound_distance(closemic_position: list, farmic_position: list
     arrival_far = min(np.flatnonzero(irs["farmic"]))
     # Should hit the closer mic before the further mic
     assert arrival_close < arrival_far
+
+
+@pytest.mark.parametrize(
+    "cfg,expected",
+    [
+        (dict(sample_rate=22050, global_volume=0.5), None),
+        (dict(will_raise="an_error", sample_rate=595959), AttributeError)
+    ]
+)
+def test_config_parse(cfg, expected):
+    if expected is None:
+        space = Space(mesh=str(TEST_MESHES[-1]), rlr_kwargs=cfg)
+        for ke, val in cfg.items():
+            assert getattr(space.ctx.config, ke) == val
+
+    else:
+        with pytest.raises(expected):
+            _ = Space(mesh=str(TEST_MESHES[-1]), rlr_kwargs=cfg)


### PR DESCRIPTION
Fixes #20 

When creating a `Space` object, we can now pass a `dict` containing kwargs to pass to the `rlr_audio_propagation` library. For instance, to set the sample rate, we'd do `Space(mesh=..., rlr_kwargs=dict(sample_rate=...))`