### PR TITLE
RMS normalization for Event + Ambience audio

### DIFF
--- a/audiblelight/ambience.py
+++ b/audiblelight/ambience.py
@@ -8,6 +8,7 @@ which is released under a permissive MIT license.
 """
 
 import random
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Iterable, Optional, Union
 
@@ -90,6 +91,7 @@ class Ambience:
 
         # Will be used to hold pre-rendered ambience
         self.audio = None
+        self.spatial_audio = OrderedDict()
 
     def __eq__(self, other: Any) -> bool:
         """
@@ -140,10 +142,17 @@ class Ambience:
         return self.audio is not None and librosa.util.valid_audio(self.audio)
 
     def load_ambience(
-        self, ignore_cache: Optional[bool] = False, normalize: Optional[bool] = True
+        self, ignore_cache: Optional[bool] = False, normalize: Optional[bool] = False
     ) -> np.ndarray:
         """
         Load the background ambience as an array with shape (channels, samples).
+
+        After calling this function once, `audio` is cached as an attribute of this Event instance, and this
+        attribute will be returned on successive calls unless `ignore_cache` is True.
+
+        Arguments:
+            ignore_cache (bool): if True, bypass cache and load audio from disk. Defaults to True.
+            normalize (bool): if True, peak normalize audio to 1.0. Defaults to False.
         """
         # If we've already loaded the audio, and it is still valid, we can return it straight away
         if self.is_audio_loaded and not ignore_cache:

--- a/audiblelight/core.py
+++ b/audiblelight/core.py
@@ -426,7 +426,7 @@ class Scene:
                 sample a random audio file from `Scene.bg_audios`.
             noise (str): either the type of noise to generate, e.g. "white", "red", or an arbitrary numeric exponent to
                 use when generating noise with `powerlaw_psd_gaussian`.
-            ref_db (Numeric): the noise floor, in decibels
+            ref_db (Numeric): the noise floor, in decibels. Defaults to `Scene.ref_db` if not provided.
             alias (str): string reference to refer to this `Ambience` object inside `Scene.ambience`
             kwargs: additional keyword arguments passed to `audiblelight.ambience.powerlaw_psd_gaussian`
         """

--- a/audiblelight/event.py
+++ b/audiblelight/event.py
@@ -480,17 +480,21 @@ class Event:
 
     # noinspection PyTypeChecker
     def load_audio(
-        self, ignore_cache: Optional[bool] = False, normalize: Optional[bool] = True
+        self, ignore_cache: Optional[bool] = False, normalize: Optional[bool] = False
     ) -> np.ndarray:
         """
         Returns the audio array of the Event.
 
         The audio will be loaded, resampled to the desired sample rate, converted to mono, and then truncated to match
-        the event start time and duration. If `normalize` (defaults to True), audio will also be normalized to have a
+        the event start time and duration. If `normalize` (defaults to False), audio will also be normalized to have a
         maximum absolute peak of 1.
 
         After calling this function once, `audio` is cached as an attribute of this Event instance, and this
         attribute will be returned on successive calls unless `ignore_cache` is True.
+
+        Arguments:
+            ignore_cache (bool): if True, bypass cache and load audio from disk. Defaults to True.
+            normalize (bool): if True, peak normalize audio to 1.0. Defaults to False.
 
         Returns:
             np.ndarray: the audio array.

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -292,7 +292,7 @@ def test_add_augmentations(audio_fpath, augmentations):
         "test_event",
     )
     # Load up the pre-augmented audio
-    init_audio = ev.load_audio(ignore_cache=True)
+    init_audio = ev.load_audio(ignore_cache=True, normalize=True)
     # Audio should be normalized, peak at +/- 1
     assert pytest.approx(np.max(np.abs(init_audio))) == 1
 
@@ -303,7 +303,7 @@ def test_add_augmentations(audio_fpath, augmentations):
     assert len(ev.augmentations) > 0
 
     # Audio should be different to the initial form after augmentation
-    aug_audio = ev.load_audio()
+    aug_audio = ev.load_audio(normalize=True)
     assert not np.array_equal(init_audio, aug_audio)
     assert ev.audio is not None
     # Audio should be normalized, peak at +/- 1


### PR DESCRIPTION
Fixes #30
Fixes #86 

- When loading `Event/Ambience` audio, we no longer peak normalize == 1.0
- Instead, we do the following:
    - Normalize audio to `RMS == 0 dB`
    - Scale so that `linear_to_db(mean(abs(audio))) == scene.ref_db + event.snr`
    - TODO: think about whether this should just be normalizing to `RMS == scene.ref_db + event.snr`? 

i.e., for a `Scene` with a -65 dB noise floor and an `Event` with `snr=5`

1. Load audio
2. Scale so that `RMS == 0dB`
3. Scale so that `mean dB = -60 (-65 + 5)`

A similar process is followed for `Ambience` objects. However, note that `Ambience` objects do not have the concept of `SNR`. Instead, they simply have a noise floor, which (by default) is set to the noise floor of the `Scene` (however, this can be overridden with `scene.add_ambience(ref_db=...)`, but maybe this isn't desirable!)