### PR TITLE
Fix DCASE source ID column

### DIFF
--- a/audiblelight/synthesize.py
+++ b/audiblelight/synthesize.py
@@ -640,9 +640,10 @@ def generate_dcase2024_metadata(scene: Scene) -> dict[str, pd.DataFrame]:
     position of each IR is linearly interpolated throughout the duration of the audio file in order to obtain a value
     for azimuth, elevation, and distance estimated at every frame.
 
-    Note that the `source number index` value is assigned independently for each class: thus, with two `telephone`
-    classes and one `femaleSpeech`, we would expect to see values of 0 and 1 for the two `telephone` instances and
-    only `0` for the `femaleSpeech` instance.
+    Note that, `source number index` value is assigned **separately** for each class (in the STARSS format):
+    thus, with two `telephone` classes and one `femaleSpeech`, we would expect to see values of 0 and 1 for the two
+    `telephone` instances and only `0` for the `femaleSpeech` instance. Events that share the same audio file are
+    always assigned the same source ID every time they occur.
 
     Finally, note that frames without sound events are omitted from the output.
     """


### PR DESCRIPTION
Fixes #89 

- Ensure `Events` are sorted by start time before iterating
    - Previously, Events were added to metadata in the order that they were added to a Scene. 
    - So, if we added a cupboard at 10 seconds, then a cupboard at 5 seconds (in that order!), the 10 second cupboard would have ID == 0, and the 5 second cupboard ID == 1
- Keep track of unique Event audio filenames
    - Now, if two Events are added with the same audio file, the source ID will be the same for both occurrences (regardless of when they occur in the Scene)