### PR TITLE
Fix `PitchShift` sampling in `generate_dataset.py`

### DIFF
--- a/scripts/experiments/generate_dataset.py
+++ b/scripts/experiments/generate_dataset.py
@@ -67,7 +67,7 @@ VALID_MATERIALS = list({mat["name"] for mat in js_out["materials"]})
 AUGMENTATIONS = {
     "pitchshift": (
         PitchShift,
-        dict(sample_rate=SAMPLE_RATE, semitones=stats.uniform(-7, 0)),
+        dict(sample_rate=SAMPLE_RATE, semitones=lambda: np.random.randint(-7, 8)),
     ),
     "speedup": (
         SpeedUp,


### PR DESCRIPTION
Fixes a stupid (one line) bug inside `generate_dataset.py`, which was causing `PitchShift` augmentations to always be applied with `semitones=-7`. 

This was simply due to my use of `scipy.stats.uniform(-7, 0)`, rather than `scipy.stats.uniform(-7, 14)` (or any other value...)