### PR TITLE
Update STARSS Mu/Sigma values

### DIFF
--- a/audiblelight/config.py
+++ b/audiblelight/config.py
@@ -97,4 +97,4 @@ AIMG_VERBOSITY = 50
 #  These values reflect the distribution of amplitude values contained within the (real)
 #  STARSS23 training data. They are hardcoded and SHOULD NOT BE CHANGED from these values.
 #  These values will be used to standardise amplitude values for synthetic data.
-AIMG_STARSS23_MU, AIMG_STARSS23_SIGMA = 0.0006132456403200415, 0.0004943698488906652
+AIMG_STARSS23_MU, AIMG_STARSS23_SIGMA = 0.0006131814582534336, 0.00048684798377322537


### PR DESCRIPTION
Self-explanatory: this PR updates `config::AIMG_STARSS23_MU` and `config::AIMG_STARSS23_SIGMA` to new values, obtained from the *entire* STARSS23 dataset (including the 12 `dev-train-sony` files with missing video recordings)